### PR TITLE
feat: scaffold Electron TypeScript app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+release/
+appdata/*
+!appdata/.gitkeep
+!appdata/config.example.json

--- a/appdata/config.example.json
+++ b/appdata/config.example.json
@@ -1,0 +1,4 @@
+{
+  "profiles": [],
+  "settings": { "maxHistory": 500, "lazyLoadThreshold": 1000, "chunkSizeDefault": 500 }
+}

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,0 +1,8 @@
+{
+  "appId": "jp.example.pgace",
+  "productName": "PgAce",
+  "files": ["dist/**", "packages/main/**", "packages/preload/**", "node_modules/**"],
+  "directories": { "output": "release" },
+  "win": { "target": ["dir", "zip"], "artifactName": "PgAce-${version}-${os}-${arch}.${ext}" },
+  "extraResources": [{ "from": "appdata", "to": "appdata" }]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "pgace",
+  "version": "0.1.0",
+  "main": "packages/main/dist/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "dev": "concurrently -k \"tsc -w -p packages\" \"vite --config packages/renderer/vite.config.ts\" \"electron .\"",
+    "build": "vite build --config packages/renderer/vite.config.ts && tsc -p packages && electron-builder --dir",
+    "dist:zip": "vite build --config packages/renderer/vite.config.ts && tsc -p packages && electron-builder -w zip",
+    "test": "tsc -p packages"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "concurrently": "^8.0.0",
+    "electron": "^27.0.0",
+    "electron-builder": "^24.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "pg": "^8.11.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -1,0 +1,56 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import path from 'node:path';
+import { Client } from 'pg';
+import type { DbConnectParams, DbQueryParams } from '../shared/src/ipc';
+
+let mainWindow: BrowserWindow | null = null;
+let db: Client | null = null;
+
+const createWindow = () => {
+  mainWindow = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    webPreferences: {
+      preload: path.join(__dirname, '../preload/dist/index.js'),
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false
+    }
+  });
+
+  const url = process.env.VITE_DEV_SERVER_URL ||
+    `file://${path.join(__dirname, '../renderer/index.html')}`;
+  mainWindow.loadURL(url);
+};
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+ipcMain.handle('db.connect', async (_event, params: DbConnectParams) => {
+  if (db) {
+    await db.end().catch(() => undefined);
+  }
+  db = new Client({
+    host: params.host,
+    port: params.port,
+    database: params.database,
+    user: params.user,
+    password: params.password
+  });
+  await db.connect();
+  return 'connected';
+});
+
+ipcMain.handle('db.query', async (_event, params: DbQueryParams) => {
+  if (!db) throw new Error('not connected');
+  const res = await db.query(params.sql);
+  return res.rows;
+});

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": ["node", "electron"]
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../shared" }]
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1,0 +1,17 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import type { DbConnectParams, DbQueryParams } from '../shared/src/ipc';
+
+const api = {
+  connect: (params: DbConnectParams) => ipcRenderer.invoke('db.connect', params),
+  query: (params: DbQueryParams) => ipcRenderer.invoke('db.query', params)
+};
+
+contextBridge.exposeInMainWorld('pgace', api);
+
+export type PgAceAPI = typeof api;
+
+declare global {
+  interface Window {
+    pgace: PgAceAPI;
+  }
+}

--- a/packages/preload/tsconfig.json
+++ b/packages/preload/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": ["node", "electron"]
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../shared" }]
+}

--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';" />
+    <title>PgAce</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/renderer/src/global.d.ts
+++ b/packages/renderer/src/global.d.ts
@@ -1,0 +1,9 @@
+import type { PgAceAPI } from '../../preload/src';
+
+declare global {
+  interface Window {
+    pgace: PgAceAPI;
+  }
+}
+
+export {};

--- a/packages/renderer/src/main.tsx
+++ b/packages/renderer/src/main.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+const App: React.FC = () => {
+  const [result, setResult] = React.useState('Ready');
+
+  const handleTest = async () => {
+    try {
+      await window.pgace.connect({
+        host: 'localhost',
+        port: 5432,
+        database: 'postgres',
+        user: 'postgres',
+        password: ''
+      });
+      const rows = await window.pgace.query({ sql: 'SELECT 1' });
+      setResult(JSON.stringify(rows));
+    } catch (e: any) {
+      setResult(e.message);
+    }
+  };
+
+  return (
+    <div>
+      <h1>PgAce</h1>
+      <button onClick={handleTest}>Test Query</button>
+      <pre>{result}</pre>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<App />);

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "jsx": "react-jsx",
+    "module": "esnext"
+  },
+  "include": ["src/**/*", "vite.config.ts"],
+  "references": [{ "path": "../shared" }]
+}

--- a/packages/renderer/vite.config.ts
+++ b/packages/renderer/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  root: path.resolve(__dirname),
+  base: './',
+  build: {
+    outDir: 'dist'
+  },
+  plugins: [react()]
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './ipc';

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -1,0 +1,13 @@
+export type IpcChannel = 'db.connect' | 'db.query';
+
+export interface DbConnectParams {
+  host: string;
+  port: number;
+  database: string;
+  user: string;
+  password: string;
+}
+
+export interface DbQueryParams {
+  sql: string;
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./main" },
+    { "path": "./preload" },
+    { "path": "./renderer" },
+    { "path": "./shared" }
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/main" },
+    { "path": "packages/preload" },
+    { "path": "packages/renderer" },
+    { "path": "packages/shared" }
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold Electron + TypeScript workspace with main, preload, renderer and shared packages
- add React renderer with example query flow
- configure build scripts and electron-builder settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934f1c7a688328b26a87516234f91c