### PR TITLE
feat: modal connection and history

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -4,7 +4,9 @@ import type { DbConnectParams, DbQueryParams, HistoryEntry } from './ipc';
 const api = {
   connect: (params: DbConnectParams) => ipcRenderer.invoke('db.connect', params),
   query: (params: DbQueryParams) => ipcRenderer.invoke('db.query', params),
-  historyList: () => ipcRenderer.invoke('history.list') as Promise<HistoryEntry[]>
+  historyList: () => ipcRenderer.invoke('history.list') as Promise<HistoryEntry[]>,
+  profileList: () =>
+    ipcRenderer.invoke('profile.list') as Promise<DbConnectParams[]>
 };
 
 contextBridge.exposeInMainWorld('pgace', api);

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -1,4 +1,8 @@
-export type IpcChannel = 'db.connect' | 'db.query';
+export type IpcChannel =
+  | 'db.connect'
+  | 'db.query'
+  | 'history.list'
+  | 'profile.list';
 
 export interface DbConnectParams {
   host: string;
@@ -9,5 +13,10 @@ export interface DbConnectParams {
 }
 
 export interface DbQueryParams {
+  sql: string;
+}
+
+export interface HistoryEntry {
+  timestamp: string;
   sql: string;
 }


### PR DESCRIPTION
## Summary
- 接続フォームをモーダル化し、履歴からの再接続と任意タイミングでの起動に対応
- 検索履歴をモーダルから再実行できるように変更

## Testing
- `npm test`
- `npx tsc -p packages/renderer`

------
https://chatgpt.com/codex/tasks/task_e_689420959dec8328a8350f9c885237d2