### PR TITLE
接続ダイアログを追加してメニューから接続先を変更可能に

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog, Menu } from 'electron';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import fs from 'node:fs/promises';
@@ -87,6 +87,26 @@ const createWindow = () => {
     // during development, load the Vite dev server
     mainWindow.loadURL('http://localhost:5173');
   }
+
+  const template = [
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'Connect...',
+          click: () => {
+            mainWindow?.webContents.send('open-connect');
+          }
+        }
+      ]
+    }
+  ];
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+
+  mainWindow.webContents.once('did-finish-load', () => {
+    mainWindow?.webContents.send('open-connect');
+  });
 };
 
 app.whenReady().then(() => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -16,7 +16,12 @@ const api = {
   listTables: (schema: string) =>
     ipcRenderer.invoke('meta.tables', { schema }) as Promise<string[]>,
   openSqlFolder: (dir?: string) =>
-    ipcRenderer.invoke('fs.openFolder', dir) as Promise<SqlFolder>
+    ipcRenderer.invoke('fs.openFolder', dir) as Promise<SqlFolder>,
+  onOpenConnect: (callback: () => void) => {
+    const wrapped = () => callback();
+    ipcRenderer.on('open-connect', wrapped);
+    return () => ipcRenderer.off('open-connect', wrapped);
+  }
 };
 
 contextBridge.exposeInMainWorld('pgace', api);

--- a/packages/renderer/src/ConnectDialog.tsx
+++ b/packages/renderer/src/ConnectDialog.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const ConnectDialog: React.FC<Props> = ({ open, onClose }) => {
+  const [host, setHost] = React.useState('');
+  const [port, setPort] = React.useState(5432);
+  const [database, setDatabase] = React.useState('');
+  const [user, setUser] = React.useState('');
+  const [password, setPassword] = React.useState('');
+
+  const handleSubmit = React.useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      try {
+        await window.pgace.connect({ host, port, database, user, password });
+        onClose();
+      } catch (err) {
+        console.error(err);
+        alert('接続に失敗しました');
+      }
+    },
+    [host, port, database, user, password, onClose]
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.3)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        style={{ background: '#fff', padding: '16px', width: '300px' }}
+      >
+        <div>
+          <label>
+            Host
+            <input
+              value={host}
+              onChange={(e) => setHost(e.target.value)}
+              style={{ width: '100%' }}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Port
+            <input
+              type="number"
+              value={port}
+              onChange={(e) => setPort(Number(e.target.value))}
+              style={{ width: '100%' }}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Database
+            <input
+              value={database}
+              onChange={(e) => setDatabase(e.target.value)}
+              style={{ width: '100%' }}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            User
+            <input
+              value={user}
+              onChange={(e) => setUser(e.target.value)}
+              style={{ width: '100%' }}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Password
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              style={{ width: '100%' }}
+            />
+          </label>
+        </div>
+        <div style={{ marginTop: '8px', textAlign: 'right' }}>
+          <button type="submit">接続</button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default ConnectDialog;

--- a/packages/renderer/src/main.tsx
+++ b/packages/renderer/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import ConnectDialog from './ConnectDialog';
 
 interface SqlFile {
   name: string;
@@ -173,6 +174,14 @@ const PanelWrapper: React.FC<{ title: string; children: React.ReactNode }> = ({
 
 const App: React.FC = () => {
   const [rows, setRows] = React.useState<any[]>([]);
+  const [connectOpen, setConnectOpen] = React.useState(true);
+
+  React.useEffect(() => {
+    const dispose = window.pgace.onOpenConnect(() => setConnectOpen(true));
+    return () => {
+      dispose && dispose();
+    };
+  }, []);
 
   return (
     <ResultContext.Provider value={{ rows, setRows }}>
@@ -201,6 +210,7 @@ const App: React.FC = () => {
           </div>
         </div>
       </div>
+      <ConnectDialog open={connectOpen} onClose={() => setConnectOpen(false)} />
     </ResultContext.Provider>
   );
 };


### PR DESCRIPTION
## 概要
- 接続ダイアログが起動しない問題を修正
- メニューバーから再度接続ダイアログを開き、接続先を変更可能に

## テスト
- `npm test`
- `npx tsc -p packages/renderer/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689479e67a3083288bd68c0a69e891db