### PR TITLE
feat: add connection history modal and fix layout

### DIFF
--- a/packages/renderer/src/ConnectDialog.tsx
+++ b/packages/renderer/src/ConnectDialog.tsx
@@ -20,6 +20,7 @@ const ConnectDialog: React.FC<Props> = ({ open, onClose }) => {
   const [user, setUser] = React.useState('');
   const [password, setPassword] = React.useState('');
   const [profiles, setProfiles] = React.useState<DbConnectParams[]>([]);
+  const [showHistory, setShowHistory] = React.useState(false);
 
   React.useEffect(() => {
     if (!open) return;
@@ -29,19 +30,13 @@ const ConnectDialog: React.FC<Props> = ({ open, onClose }) => {
       .catch(() => setProfiles([]));
   }, [open]);
 
-  const handleSelectProfile = React.useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const idx = Number(e.target.value);
-      const p = profiles[idx];
-      if (!p) return;
-      setHost(p.host);
-      setPort(p.port);
-      setDatabase(p.database);
-      setUser(p.user);
-      setPassword(p.password);
-    },
-    [profiles]
-  );
+  const applyProfile = React.useCallback((p: DbConnectParams) => {
+    setHost(p.host);
+    setPort(p.port);
+    setDatabase(p.database);
+    setUser(p.user);
+    setPassword(p.password);
+  }, []);
 
   const handleSubmit = React.useCallback(
     async (e: React.FormEvent) => {
@@ -79,22 +74,10 @@ const ConnectDialog: React.FC<Props> = ({ open, onClose }) => {
         style={{ background: '#fff', padding: '16px', width: '300px' }}
       >
         {profiles.length > 0 && (
-          <div>
-            <label>
+          <div style={{ marginBottom: '8px' }}>
+            <button type="button" onClick={() => setShowHistory(true)}>
               履歴
-              <select
-                style={{ width: '100%' }}
-                defaultValue=""
-                onChange={handleSelectProfile}
-              >
-                <option value="" disabled>
-                  選択してください
-                </option>
-                {profiles.map((p, i) => (
-                  <option key={i} value={i}>{`${p.host}:${p.port}/${p.database} (${p.user})`}</option>
-                ))}
-              </select>
-            </label>
+            </button>
           </div>
         )}
         <div>
@@ -153,6 +136,53 @@ const ConnectDialog: React.FC<Props> = ({ open, onClose }) => {
           <button type="submit">接続</button>
         </div>
       </form>
+
+      {showHistory && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: 'rgba(0,0,0,0.3)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1100
+          }}
+        >
+          <div
+            style={{
+              background: '#fff',
+              padding: '16px',
+              width: '300px',
+              maxHeight: '80%',
+              overflow: 'auto'
+            }}
+          >
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {profiles.map((p, i) => (
+                <li key={i} style={{ marginBottom: '8px' }}>
+                  <button
+                    type="button"
+                    style={{ width: '100%' }}
+                    onClick={() => {
+                      applyProfile(p);
+                      setShowHistory(false);
+                    }}
+                  >{`${p.host}:${p.port}/${p.database} (${p.user})`}</button>
+                </li>
+              ))}
+            </ul>
+            <div style={{ textAlign: 'right', marginTop: '8px' }}>
+              <button type="button" onClick={() => setShowHistory(false)}>
+                閉じる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/renderer/src/main.tsx
+++ b/packages/renderer/src/main.tsx
@@ -101,9 +101,11 @@ const SqlEditor: React.FC = () => {
 
   const runQuery = React.useCallback(async () => {
     try {
-      const rows = await window.pgace.query({ sql });
-      setRows(rows);
+      const res = await window.pgace.query({ sql });
+      if (!Array.isArray(res)) throw new Error('invalid response');
+      setRows(res);
     } catch (e: any) {
+      console.error(e);
       setRows([{ error: String(e) }]);
     }
   }, [sql, setRows]);
@@ -129,7 +131,7 @@ const ResultGrid: React.FC = () => {
   const [selectedCol, setSelectedCol] = React.useState<string | null>(null);
   const [colWidths, setColWidths] = React.useState<Record<string, number>>({});
 
-  if (rows.length === 0) {
+  if (!Array.isArray(rows) || rows.length === 0) {
     return <div style={{ padding: '8px' }}>結果なし</div>;
   }
 
@@ -230,9 +232,9 @@ const PanelWrapper: React.FC<{ title: string; children: React.ReactNode }> = ({
     style={{
       flex: 1,
       border: '1px solid #ccc',
-      margin: '4px',
       display: 'flex',
-      flexDirection: 'column'
+      flexDirection: 'column',
+      overflow: 'hidden'
     }}
   >
     <div style={{ background: '#eee', padding: '4px' }}>{title}</div>
@@ -253,14 +255,14 @@ const App: React.FC = () => {
 
   return (
     <ResultContext.Provider value={{ rows, setRows }}>
-      <div style={{ display: 'flex', height: '100vh' }}>
-        <div style={{ flexBasis: '20%', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ display: 'flex', height: '100vh', gap: '4px', overflow: 'hidden' }}>
+        <div style={{ flexBasis: '20%', display: 'flex', flexDirection: 'column', gap: '4px' }}>
           <PanelWrapper title="DBエクスプローラ">
             <DbExplorer />
           </PanelWrapper>
         </div>
-        <div style={{ flex: 1, display: 'flex' }}>
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <div style={{ flex: 1, display: 'flex', gap: '4px', overflow: 'hidden' }}>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '4px' }}>
             <PanelWrapper title="SQLエディタ">
               <SqlEditor />
             </PanelWrapper>
@@ -268,7 +270,7 @@ const App: React.FC = () => {
               <ResultGrid />
             </PanelWrapper>
           </div>
-          <div style={{ flexBasis: '25%', display: 'flex', flexDirection: 'column' }}>
+          <div style={{ flexBasis: '25%', display: 'flex', flexDirection: 'column', gap: '4px' }}>
             <PanelWrapper title="SQLエクスプローラ">
               <SqlExplorer />
             </PanelWrapper>


### PR DESCRIPTION
## Summary
- replace connect history combo with modal selection dialog
- adjust panel layout to avoid full-page scrolling
- guard query results to prevent blank screen after search

## Testing
- `npm test`
- `npx tsc -p packages/renderer`


------
https://chatgpt.com/codex/tasks/task_e_6895445e051883289891fefe774afa43