### PR TITLE
feat: add connection history modal and improve logging

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, Menu } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog, Menu, crashReporter } from 'electron';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import fs from 'node:fs/promises';
@@ -18,6 +18,42 @@ const APPDATA_DIR = path.join(app.getAppPath(), 'appdata');
 const HISTORY_FILE = path.join(APPDATA_DIR, 'history.log');
 const HISTORY_MAX = 500;
 const CONFIG_FILE = path.join(APPDATA_DIR, 'config.json');
+const ERROR_LOG = path.join(APPDATA_DIR, 'error.log');
+const CRASH_DIR = path.join(APPDATA_DIR, 'crashes');
+
+app.setPath('crashDumps', CRASH_DIR);
+crashReporter.start({ submitURL: '', uploadToServer: false });
+
+const logError = async (msg: string, err?: unknown) => {
+  const detail =
+    err instanceof Error
+      ? err.stack ?? err.message
+      : err !== undefined
+      ? JSON.stringify(err)
+      : '';
+  const line = `${new Date().toISOString()} ${msg}${detail ? ` ${detail}` : ''}`;
+  try {
+    await fs.mkdir(APPDATA_DIR, { recursive: true });
+    await fs.appendFile(ERROR_LOG, line + '\n', 'utf8');
+  } catch {
+    // ignore logging errors
+  }
+  console.error(line);
+};
+
+process.on('uncaughtException', (err) => {
+  void logError('uncaughtException', err);
+});
+process.on('unhandledRejection', (reason) => {
+  void logError('unhandledRejection', reason);
+});
+
+app.on('child-process-gone', (_event, details) => {
+  void logError('child-process-gone', details);
+  if (details.type === 'GPU') {
+    mainWindow?.reload();
+  }
+});
 
 interface Config {
   profiles: DbConnectParams[];
@@ -77,6 +113,11 @@ const createWindow = () => {
     }
   });
 
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    void logError('render-process-gone', details);
+    mainWindow?.reload();
+  });
+
   if (app.isPackaged) {
     // load the built renderer HTML from the renderer's dist directory
     const fileUrl = pathToFileURL(
@@ -131,16 +172,26 @@ ipcMain.handle('db.connect', async (_event, params: DbConnectParams) => {
     user: params.user,
     password: params.password
   });
-  await db.connect();
+  try {
+    await db.connect();
+  } catch (e) {
+    await logError('db.connect error', e);
+    throw e;
+  }
   await saveProfile(params);
   return 'connected';
 });
 
 ipcMain.handle('db.query', async (_event, params: DbQueryParams) => {
   if (!db) throw new Error('not connected');
-  const res = await db.query(params.sql);
-  await appendHistory(params.sql);
-  return res.rows;
+  try {
+    const res = await db.query(params.sql);
+    await appendHistory(params.sql);
+    return res.rows;
+  } catch (e) {
+    await logError('db.query error', e);
+    throw e;
+  }
 });
 
 ipcMain.handle('profile.list', async () => {
@@ -161,12 +212,17 @@ ipcMain.handle('history.list', async () => {
   }
 });
 ipcMain.handle('meta.tables', async (_event, params: { schema: string }) => {
-  if (!db) throw new Error('not connected');
-  const res = await db.query(
-    'SELECT table_name FROM information_schema.tables WHERE table_schema = $1 ORDER BY table_name',
-    [params.schema]
-  );
-  return res.rows.map((r: any) => r.table_name as string);
+  if (!db) return [];
+  try {
+    const res = await db.query(
+      'SELECT table_name FROM information_schema.tables WHERE table_schema = $1 ORDER BY table_name',
+      [params.schema]
+    );
+    return res.rows.map((r: any) => r.table_name as string);
+  } catch (e) {
+    await logError('meta.tables error', e);
+    return [];
+  }
 });
 ipcMain.handle('fs.openFolder', async (_event, dir?: string): Promise<SqlFolder> => {
   const readDir = async (d: string): Promise<SqlFolder> => {

--- a/packages/renderer/src/ConnectDialog.tsx
+++ b/packages/renderer/src/ConnectDialog.tsx
@@ -20,6 +20,7 @@ const ConnectDialog: React.FC<Props> = ({ open, onClose }) => {
   const [user, setUser] = React.useState('');
   const [password, setPassword] = React.useState('');
   const [profiles, setProfiles] = React.useState<DbConnectParams[]>([]);
+  const [showHistory, setShowHistory] = React.useState(false);
 
   React.useEffect(() => {
     if (!open) return;
@@ -29,19 +30,13 @@ const ConnectDialog: React.FC<Props> = ({ open, onClose }) => {
       .catch(() => setProfiles([]));
   }, [open]);
 
-  const handleSelectProfile = React.useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const idx = Number(e.target.value);
-      const p = profiles[idx];
-      if (!p) return;
-      setHost(p.host);
-      setPort(p.port);
-      setDatabase(p.database);
-      setUser(p.user);
-      setPassword(p.password);
-    },
-    [profiles]
-  );
+  const applyProfile = React.useCallback((p: DbConnectParams) => {
+    setHost(p.host);
+    setPort(p.port);
+    setDatabase(p.database);
+    setUser(p.user);
+    setPassword(p.password);
+  }, []);
 
   const handleSubmit = React.useCallback(
     async (e: React.FormEvent) => {
@@ -79,22 +74,10 @@ const ConnectDialog: React.FC<Props> = ({ open, onClose }) => {
         style={{ background: '#fff', padding: '16px', width: '300px' }}
       >
         {profiles.length > 0 && (
-          <div>
-            <label>
+          <div style={{ marginBottom: '8px' }}>
+            <button type="button" onClick={() => setShowHistory(true)}>
               履歴
-              <select
-                style={{ width: '100%' }}
-                defaultValue=""
-                onChange={handleSelectProfile}
-              >
-                <option value="" disabled>
-                  選択してください
-                </option>
-                {profiles.map((p, i) => (
-                  <option key={i} value={i}>{`${p.host}:${p.port}/${p.database} (${p.user})`}</option>
-                ))}
-              </select>
-            </label>
+            </button>
           </div>
         )}
         <div>
@@ -153,6 +136,53 @@ const ConnectDialog: React.FC<Props> = ({ open, onClose }) => {
           <button type="submit">接続</button>
         </div>
       </form>
+
+      {showHistory && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: 'rgba(0,0,0,0.3)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1100
+          }}
+        >
+          <div
+            style={{
+              background: '#fff',
+              padding: '16px',
+              width: '300px',
+              maxHeight: '80%',
+              overflow: 'auto'
+            }}
+          >
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {profiles.map((p, i) => (
+                <li key={i} style={{ marginBottom: '8px' }}>
+                  <button
+                    type="button"
+                    style={{ width: '100%' }}
+                    onClick={() => {
+                      applyProfile(p);
+                      setShowHistory(false);
+                    }}
+                  >{`${p.host}:${p.port}/${p.database} (${p.user})`}</button>
+                </li>
+              ))}
+            </ul>
+            <div style={{ textAlign: 'right', marginTop: '8px' }}>
+              <button type="button" onClick={() => setShowHistory(false)}>
+                閉じる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/renderer/src/main.tsx
+++ b/packages/renderer/src/main.tsx
@@ -101,9 +101,11 @@ const SqlEditor: React.FC = () => {
 
   const runQuery = React.useCallback(async () => {
     try {
-      const rows = await window.pgace.query({ sql });
-      setRows(rows);
+      const res = await window.pgace.query({ sql });
+      if (!Array.isArray(res)) throw new Error('invalid response');
+      setRows(res);
     } catch (e: any) {
+      console.error(e);
       setRows([{ error: String(e) }]);
     }
   }, [sql, setRows]);
@@ -129,7 +131,7 @@ const ResultGrid: React.FC = () => {
   const [selectedCol, setSelectedCol] = React.useState<string | null>(null);
   const [colWidths, setColWidths] = React.useState<Record<string, number>>({});
 
-  if (rows.length === 0) {
+  if (!Array.isArray(rows) || rows.length === 0) {
     return <div style={{ padding: '8px' }}>結果なし</div>;
   }
 
@@ -230,9 +232,9 @@ const PanelWrapper: React.FC<{ title: string; children: React.ReactNode }> = ({
     style={{
       flex: 1,
       border: '1px solid #ccc',
-      margin: '4px',
       display: 'flex',
-      flexDirection: 'column'
+      flexDirection: 'column',
+      overflow: 'hidden'
     }}
   >
     <div style={{ background: '#eee', padding: '4px' }}>{title}</div>
@@ -253,14 +255,14 @@ const App: React.FC = () => {
 
   return (
     <ResultContext.Provider value={{ rows, setRows }}>
-      <div style={{ display: 'flex', height: '100vh' }}>
-        <div style={{ flexBasis: '20%', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ display: 'flex', height: '100vh', gap: '4px', overflow: 'hidden' }}>
+        <div style={{ flexBasis: '20%', display: 'flex', flexDirection: 'column', gap: '4px' }}>
           <PanelWrapper title="DBエクスプローラ">
             <DbExplorer />
           </PanelWrapper>
         </div>
-        <div style={{ flex: 1, display: 'flex' }}>
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <div style={{ flex: 1, display: 'flex', gap: '4px', overflow: 'hidden' }}>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '4px' }}>
             <PanelWrapper title="SQLエディタ">
               <SqlEditor />
             </PanelWrapper>
@@ -268,7 +270,7 @@ const App: React.FC = () => {
               <ResultGrid />
             </PanelWrapper>
           </div>
-          <div style={{ flexBasis: '25%', display: 'flex', flexDirection: 'column' }}>
+          <div style={{ flexBasis: '25%', display: 'flex', flexDirection: 'column', gap: '4px' }}>
             <PanelWrapper title="SQLエクスプローラ">
               <SqlExplorer />
             </PanelWrapper>


### PR DESCRIPTION
## Summary
- replace connect history combo with modal selection dialog
- adjust panel layout to avoid full-page scrolling
- guard query results to prevent blank screen after search
- return empty table list when disconnected to avoid meta request crash
- log GPU/renderer crashes and database errors instead of disabling hardware acceleration
- reload main window when GPU or renderer process crashes
- record stack traces to error.log and save crash dumps for investigation

## Testing
- `npm test`
- `npx tsc -p packages/renderer`


------
https://chatgpt.com/codex/tasks/task_e_6895445e051883289891fefe774afa43